### PR TITLE
fix: change module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tl-framework/goframework
+module github.com/thiagotilid/goframework
 
 go 1.19
 


### PR DESCRIPTION
changing module from github.com/tl-framework/goframework to github.com/thiagotilid/goframework